### PR TITLE
Add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.3",
   "description": "A universally-unique, lexicographically-sortable, identifier generator",
   "main": "./lib/index.umd.js",
+  "browser": "./lib/index.umd.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "repository": {


### PR DESCRIPTION
This is related to #54.

When building projects using webpack it is common to exclude the `node_modules` folder from transpiration because this causes the build times to sky rocket (especially in projects with big dependency trees).

It should be safe to assume that a package was transpiled so it runs on ES5, to cut down on transpilation times.

The `ulid` package does seem to have a transpiled UMD bundle in `lib/index.umd.js`, which webpack supports. The error we saw in #54 (and which I'm seeing in my projects) is due to webpack not picking up on this transpiled bundle, because by default it tries the [module alias fields in this order](https://webpack.js.org/configuration/resolve/#resolve-mainfields):

1. `browser`
2. `module`
3. `main`

The `package.json` of `ulid` contains the following relevant fields:

```json
  "main": "./lib/index.umd.js",
  "module": "./lib/index.js",
```

So, `module` is being picked up before `main` by webpack, causing builds to break.
As you've said, adding transpilation (and enabling it for `node_modules`) should fix the problem. I propose however, that you add a `browser` field, so by default webpack builds will work as well:

 ```diff
   "main": "./lib/index.umd.js",
+ "browser": "./lib/index.umd.js",
   "module": "./lib/index.js",
```

I've tested it locally and my webpack build works when these changes are applied.