### PR TITLE
Web worker support

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,6 +16,10 @@ function createError(message: string): LibError {
   return err
 }
 
+function inWebWorker(): boolean {
+  return typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope
+}
+
 // These values should NEVER change. If
 // they do, we're no longer making ulids!
 const ENCODING = "0123456789ABCDEFGHJKMNPQRSTVWXYZ" // Crockford's Base32
@@ -117,7 +121,7 @@ export function decodeTime(id: string): number {
 
 export function detectPrng(allowInsecure: boolean = false, root?: any): PRNG {
   if (!root) {
-    root = typeof window !== "undefined" ? window : null
+    root = typeof window !== "undefined" ? window : inWebWorker() ? self : null
   }
 
   const browserCrypto = root && (root.crypto || root.msCrypto)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,7 @@ function createError(message: string): LibError {
 }
 
 function inWebWorker(): boolean {
+  // @ts-ignore
   return typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": [
-      "ES5", "ES6", "ES7", "DOM", "WebWorker"
+      "ES5", "ES6", "ES7", "DOM"
     ],
     "types": [ "Node" ],
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": [
-      "ES5", "ES6", "ES7", "DOM"
+      "ES5", "ES6", "ES7", "DOM", "WebWorker"
     ],
     "types": [ "Node" ],
     "declaration": true,


### PR DESCRIPTION
This PR adds support for detecting crypto within a Web Worker, where `window` is not defined but `self` (and therefore `self.crypto`) is.

Fixes #83