### PR TITLE
Fix generated ULID examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ import { monotonicFactory } from 'ulid'
 const ulid = monotonicFactory()
 
 // Strict ordering for the same timestamp, by incrementing the least-significant random bit by 1
-ulid(150000) // 000XAL6S41ACTAV9WEVGEMMVR8
-ulid(150000) // 000XAL6S41ACTAV9WEVGEMMVR9
-ulid(150000) // 000XAL6S41ACTAV9WEVGEMMVRA
-ulid(150000) // 000XAL6S41ACTAV9WEVGEMMVRB
-ulid(150000) // 000XAL6S41ACTAV9WEVGEMMVRC
+ulid(150000) // 0000004JFG7NP20TJP26ZJDASS
+ulid(150000) // 0000004JFG7NP20TJP26ZJDAST
+ulid(150000) // 0000004JFG7NP20TJP26ZJDASV
+ulid(150000) // 0000004JFG7NP20TJP26ZJDASW
+ulid(150000) // 0000004JFG7NP20TJP26ZJDASX
 
 // Even if a lower timestamp is passed (or generated), it will preserve sort order
-ulid(100000) // 000XAL6S41ACTAV9WEVGEMMVRD
+ulid(100000) // 0000004JFG7NP20TJP26ZJDASY
 ```
 
 ### Pseudo-Random Number Generators


### PR DESCRIPTION
Hi! I'm writing a new Ruby library for handling ULID in these days.
Now I’m testing other implementations examples in https://github.com/kachick/ruby-ulid/issues/53

And I have found weird examples in this original repository.

`000XAL6S41ACTAV9WEVGEMMVR8` looks weird example from 2 reasons.

* Containing `L` in the encoded string. In my understanding, `Crockford's base32` does not contain `L` for the encoded product. So ULID can ignore `L`, Is this correct understanding? ref: https://github.com/ulid/spec/issues/38, https://github.com/kachick/ruby-ulid/issues/57
* The generated timestamp part looks incorrect for given seed timestamp even if handling `L` as `1`.

Returned values from current `npm` version looks correct.

```console
$ node -v
v14.16.0
$ npm list
ulid@2.3.0 /Users/kachick/repos/ulid-javascript
```

```javascript
const ULID = require('ulid')
mf = ULID.monotonicFactory()
mf(150000) // 0000004JFG7NP20TJP26ZJDASS
mf(150000) // 0000004JFG7NP20TJP26ZJDAST
mf(150000) // 0000004JFG7NP20TJP26ZJDASV
mf(150000) // 0000004JFG7NP20TJP26ZJDAST
mf(150000) // 0000004JFG7NP20TJP26ZJDASW
mf(150000) // 0000004JFG7NP20TJP26ZJDASX
mf(100000) // 0000004JFG7NP20TJP26ZJDASY
```