### PR TITLE
Fix npm badge downloads per month

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </h1>
 
 [![Build Status](https://travis-ci.org/ulid/javascript.svg?branch=master)](https://travis-ci.org/ulid/javascript) [![codecov](https://codecov.io/gh/ulid/javascript/branch/master/graph/badge.svg)](https://codecov.io/gh/ulid/javascript)
-[![npm](https://img.shields.io/npm/dm/localeval.svg)](https://www.npmjs.com/package/ulid)
+[![npm](https://img.shields.io/npm/dm/ulid.svg)](https://www.npmjs.com/package/ulid)
 
 # Universally Unique Lexicographically Sortable Identifier
 


### PR DESCRIPTION
It's showing 500 downloads per month right now, instead of 1.3Mi. This fixes the image url