### PR TITLE
README Fix: Remove ponit about MAC address issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 UUID can be suboptimal for many uses-cases because:
 
 - It isn't the most character efficient way of encoding 128 bits of randomness
-- UUID v1/v2 is impractical in many environments, as it requires access to a unique, stable MAC address
 - UUID v3/v5 requires a unique seed and produces randomly distributed IDs, which can cause fragmentation in many data structures
 - UUID v4 provides no other information than randomness which can cause fragmentation in many data structures
 


### PR DESCRIPTION
The claim that UUIDs require access to the MAC address should be removed, as it's not technically correct.  RFC4122 allows for the `node` field to be set to a random value if a MAC address isn't available. Ref: https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.6

FWIW, the `uuid` module has always used a random value for the `node` field and never had any complaints.  In fact, this ultimately turned out to be a good thing, as embedding MAC addresses in IDs that might be shared publicly has come to be seen as something of a security concern.  I guess if you're looking for reasons to take down UUID you could list that instead?  But where `uuid` is concerned it's not an issue.