### PR TITLE
Look for crypto library using `self` keyword instead of `window`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -117,7 +117,7 @@ export function decodeTime(id: string): number {
 
 export function detectPrng(allowInsecure: boolean = false, root?: any): PRNG {
   if (!root) {
-    root = typeof window !== "undefined" ? window : null
+    root = typeof self !== "undefined" ? self : null
   }
 
   const browserCrypto = root && (root.crypto || root.msCrypto)


### PR DESCRIPTION
The name of the global namespace varies in different execution environments. The `self` keyword allows accessing `crypto` in both the browser and WorkerGlobalScope (web workers/service workers), whereas `window` only works for the browser. This change allows the library to work in more environments than previously.

**References**

[Window.self](https://developer.mozilla.org/en-US/docs/Web/API/Window/self)
[WorkerGlobalScope.self](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/self)
[Web APIs available in Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers#web_apis_available_in_workers)