### PR TITLE
Prefer Globalthis, fall back to window when detecting root

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -117,7 +117,11 @@ export function decodeTime(id: string): number {
 
 export function detectPrng(allowInsecure: boolean = false, root?: any): PRNG {
   if (!root) {
-    root = typeof window !== "undefined" ? window : null
+    root = typeof globalThis !== "undefined"
+        ? globalThis
+        : typeof window !== "undefined"
+        ? window
+        : null
   }
 
   const browserCrypto = root && (root.crypto || root.msCrypto)


### PR DESCRIPTION
Ran into weird calling code inside a webworker in android chrome that calls ulid() exported here, and then hits this error. Can't see where the bug is, but regardless, should check for globalThis to be compatable with webworkers.