### PR TITLE
fix(incrementBase32): fix error message when unable to increment the input

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -22,7 +22,7 @@ function incrementBase32(str) {
     var char = void 0;
     var charIndex = void 0;
     var maxCharIndex = ENCODING_LEN - 1;
-    while (!done && index-- >= 0) {
+    while (!done && --index >= 0) {
         char = str[index];
         charIndex = ENCODING.indexOf(char);
         if (charIndex === -1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -22,7 +22,7 @@ export function incrementBase32(str) {
     let char;
     let charIndex;
     const maxCharIndex = ENCODING_LEN - 1;
-    while (!done && index-- >= 0) {
+    while (!done && --index >= 0) {
         char = str[index];
         charIndex = ENCODING.indexOf(char);
         if (charIndex === -1) {

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -28,7 +28,7 @@ function incrementBase32(str) {
     var char = void 0;
     var charIndex = void 0;
     var maxCharIndex = ENCODING_LEN - 1;
-    while (!done && index-- >= 0) {
+    while (!done && --index >= 0) {
         char = str[index];
         charIndex = ENCODING.indexOf(char);
         if (charIndex === -1) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -37,7 +37,7 @@ export function incrementBase32(str: string): string {
   let char
   let charIndex
   const maxCharIndex = ENCODING_LEN - 1
-  while (!done && index-- >= 0) {
+  while (!done && --index >= 0) {
     char = str[index]
     charIndex = ENCODING.indexOf(char)
     if (charIndex === -1) {

--- a/test.js
+++ b/test.js
@@ -36,6 +36,8 @@ describe("ulid", function() {
     it("throws when it cannot increment", function() {
       assert.throws(function() {
         ULID.incrementBase32("ZZZ")
+      }, {
+        message: "cannot increment this string"
       })
     })
   })


### PR DESCRIPTION
Currently the below errors with `Error: incorrectly encoded string`:

```js
const ULID = require('ulid')
ULID.incrementBase32('ZZZ')
```

However, the error message seems wrong here because `ZZZ` is correctly encoded base32 string. I think the error message should be `cannot increment this string` here. This PR fixes this issue by incrementing `index` counter before comparing with `>=0`.