### PR TITLE
feat: export min and max values for ULID

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,6 +24,9 @@ const TIME_MAX = Math.pow(2, 48) - 1
 const TIME_LEN = 10
 const RANDOM_LEN = 16
 
+export const MIN_ULID = "00000000000000000000000000";
+export const MAX_ULID = "7ZZZZZZZZZZZZZZZZZZZZZZZZZ";
+
 export function replaceCharAt(str: string, index: number, char: string) {
   if (index > str.length - 1) {
     return str

--- a/test.js
+++ b/test.js
@@ -226,4 +226,14 @@ describe("ulid", function() {
       })
     })
   })
+
+  describe("constants", function () {
+    it("should export MIN_ULID", function () {
+      assert.strictEqual(ULID.MIN_ULID, "00000000000000000000000000");
+    });
+
+    it("should export MAX_ULID", function () {
+      assert.strictEqual(ULID.MAX_ULID, "7ZZZZZZZZZZZZZZZZZZZZZZZZZ");
+    });
+  });
 })


### PR DESCRIPTION
Exports new constants `MIN_ULID` and `MAX_ULID`. These can be useful when doing range queries to look for valid ULIDs, eg 

```
id > `${ULID.MIN_ULID} AND id < `${ULID.MAX_ULID}
```