### PR TITLE
add a newline to the result to remove the percentage in the CLI output

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,4 +1,4 @@
 #! /usr/bin/env node
 
 var ULID = require('../dist/index.umd.js')
-process.stdout.write(ULID.ulid())
+process.stdout.write(ULID.ulid() + '\n')


### PR DESCRIPTION
When installed globally via npm, yarn, or bun, the output returns a ULID but with a percentage at the end as it uses `process.stdout.write` instead of the common `console.log`. This, however, does not append a new line insertion which explains why there is a percent sign at the ened of every result.

To fix the this, simply add a new line insertion at the end to omit the percent sign and return just the generated ULID. 

<img width="204" alt="Screenshot 2024-08-18 at 11 40 01 PM" src="https://github.com/user-attachments/assets/0d6032dd-1df9-41c5-af26-3ac2c92c390b">
