### PR TITLE
Always use globalThis.crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "ulid": "dist/cli.js"
       },
       "devDependencies": {
-        "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-commonjs": "^28.0.3",
         "@rollup/plugin-node-resolve": "^16.0.1",
         "@rollup/plugin-typescript": "^12.1.2",
@@ -456,24 +455,6 @@
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-alias": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
-      "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "28.0.3",

--- a/package.json
+++ b/package.json
@@ -9,35 +9,29 @@
         "require": "./dist/index.d.cts",
         "default": "./dist/index.d.ts"
       },
-      "node": {
-        "require": "./dist/node/index.cjs",
-        "default": "./dist/node/index.js"
-      },
       "default": {
-        "require": "./dist/browser/index.cjs",
-        "default": "./dist/browser/index.js"
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.js"
       }
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/node/index.cjs",
-  "module": "./dist/node/index.js",
+  "main": "dist/index.cjs",
+  "module": "./dist/index.js",
   "browser": {
-    "./dist/node/index.cjs": "./dist/browser/index.cjs",
-    "./dist/node/index.js": "./dist/browser/index.js"
+    "./dist/index.cjs": "./dist/index.cjs",
+    "./dist/index.js": "./dist/index.js"
   },
-  "react-native": "./dist/browser/index.cjs",
+  "react-native": "./dist/index.cjs",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "bin": "./dist/cli.js",
   "scripts": {
     "bench": "npm run build && node test/benchmark.js",
-    "build": "npm run clean && npm run build:node:cjs && npm run build:node:esm && npm run build:browser:cjs && npm run build:browser:esm && npm run build:cli && npm run build:types",
-    "build:browser:cjs": "FMT=cjs ENV=browser rollup -c --name ulidx",
-    "build:browser:esm": "FMT=esm ENV=browser rollup -c --name ulidx",
+    "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:cli && npm run build:types",
     "build:cli": "FMT=esm ENV=cli rollup -c && chmod +x ./dist/cli.js",
-    "build:node:cjs": "FMT=cjs ENV=node rollup -c",
-    "build:node:esm": "FMT=esm ENV=node rollup -c",
+    "build:cjs": "FMT=cjs rollup -c",
+    "build:esm": "FMT=esm rollup -c",
     "build:types": "tsc -p tsconfig.dec.json --emitDeclarationOnly  && find ./dist -name '*.d.ts' -exec sh -c 'cp {} $(dirname {})/$(basename -s .d.ts {}).d.cts' \\;",
     "clean": "rm -rf ./dist",
     "format": "prettier --write \"{{source,test}/**/*.{js,ts},rollup.config.js,vitest.config.js}\"",
@@ -61,7 +55,6 @@
   },
   "homepage": "https://github.com/ulid/javascript#readme",
   "devDependencies": {
-    "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,12 @@
-import { builtinModules } from "node:module";
 import typescript from "@rollup/plugin-typescript";
 import resolve from "@rollup/plugin-node-resolve";
-import alias from "@rollup/plugin-alias";
-import pkg from "./package.json" with { type: "json" };
 
 const EXTENSIONS = [".js", ".ts"];
-const ENV = process.env.ENV ? process.env.ENV : "node";
+const ENV = process.env.ENV ? process.env.ENV : "default";
 const FMT = process.env.FMT ? process.env.FMT : "esm";
 
 const entry = ENV === "cli" ? "source/cli.ts" : "source/index.ts";
-const output = ENV === "cli" ? "dist" : `dist/${ENV}`;
+const output = "dist";
 
 const plugins = [
     typescript({
@@ -17,21 +14,9 @@ const plugins = [
     }),
     resolve({ extensions: EXTENSIONS })
 ];
-if (ENV !== "node") {
-    plugins.unshift(
-        alias({
-            entries: [{ find: "node:crypto", replacement: "./stub.js" }]
-        })
-    );
-}
 const extension = FMT === "cjs" ? "cjs" : "js";
-const externals =
-    FMT === "esm"
-        ? [...builtinModules, ...(pkg.dependencies ? Object.keys(pkg.dependencies) : [])]
-        : [...builtinModules];
 
 export default {
-    external: externals,
     input: entry,
     output: [
         {

--- a/source/stub.ts
+++ b/source/stub.ts
@@ -1,1 +1,0 @@
-export default undefined;

--- a/source/uuid.ts
+++ b/source/uuid.ts
@@ -1,4 +1,3 @@
-import { UUID } from "crypto";
 import { ULID_REGEX, UUID_REGEX } from "./constants.js";
 import { crockfordDecode, crockfordEncode } from "./crockford.js";
 import { ULIDError, ULIDErrorCode } from "./error.js";
@@ -9,7 +8,7 @@ import { ULID } from "./types.js";
  * @param ulid The ULID to convert
  * @returns A UUID string
  */
-export function ulidToUUID(ulid: ULID): UUID {
+export function ulidToUUID(ulid: ULID): string {
     const isValid = ULID_REGEX.test(ulid);
     if (!isValid) {
         throw new ULIDError(ULIDErrorCode.ULIDInvalid, `Invalid ULID: ${ulid}`);
@@ -28,7 +27,7 @@ export function ulidToUUID(ulid: ULID): UUID {
         uuid.substring(16, 20) +
         "-" +
         uuid.substring(20);
-    return uuid.toUpperCase() as UUID;
+    return uuid.toUpperCase();
 }
 
 /**

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,5 +1,5 @@
 import Benchmark from "benchmark";
-import { ulid } from "../dist/node/index.js";
+import { ulid } from "ulid";
 
 const suite = new Benchmark.Suite();
 


### PR DESCRIPTION
`globalThis.crypto.getRandomValues()` should work pretty much everywhere now, so thankfully there's no need to maintain separate builds for Node.js vs. browser/worker runtimes anymore.

I saw you're planning on a larger refactor, so don't feel bad if you decide to close this! It's just a selfish PR because I keep bumping into issues when using this package in worker runtimes, so I'd love to see the Node.js imports removed for good.